### PR TITLE
Add gcp_principals input for self-hosted Nuon on GCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.terraform

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Terraform AWS ECR Access
 
-A module for setting up ECR access for [container image](https://docs.nuon.co/guides/container-image-components#ecr-access-iam-role) components on Nuon. This module is published to the [Terraform Registry](https://registry.terraform.io/modules/nuonco/ecr-access/aws).
+A module for setting up ECR access for [container image](https://docs.nuon.co/guides/container-image-components#aws-ecr-access-iam-role) components on Nuon. This module is published to the [Terraform Registry](https://registry.terraform.io/modules/nuonco/ecr-access/aws).
 
 ## Usage
 
-To setup the IAM role granting access to Nuon to pull images from an ECR repository, please use the following snippet:
+To setup the IAM role granting access to Nuon-hosted (AWS) installs to pull images from an ECR repository, use the following snippet:
 
 ```hcl
 module "nuon_aws_ecr_access" {
@@ -13,3 +13,31 @@ module "nuon_aws_ecr_access" {
   repository_arns = ["<repository-arn>"]
 }
 ```
+
+### Customers running self-hosted Nuon on GCP
+
+If some of your customers run [self-hosted Nuon on GCP](https://docs.nuon.co/guides/self-hosted/gcp), pass each customer's
+ctl-api service account so the trust policy also accepts their GCP-issued OIDC tokens:
+
+```hcl
+module "nuon_aws_ecr_access" {
+  source = "nuonco/ecr-access/aws"
+
+  repository_arns = ["<repository-arn>"]
+
+  gcp_principals = [
+    {
+      service_account_unique_id = "123456789012345678901"
+      service_account_email     = "ctl-api-<install>@<customer-project>.iam.gserviceaccount.com"
+    },
+  ]
+}
+```
+
+The `service_account_unique_id` is the 21-digit numeric ID of the SA. Customers can find it with:
+
+```bash
+gcloud iam service-accounts describe <email> --format='value(uniqueId)'
+```
+
+This is additive — the role still accepts the default Nuon-hosted (AWS) principal.

--- a/trust_policy.tf
+++ b/trust_policy.tf
@@ -3,7 +3,7 @@ locals {
     "arn:aws:iam::814326426574:root",
   ]
   support_principals = [
-    // NOTE: the following trust policies are setup to help the Nuon team do 
+    // NOTE: the following trust policies are setup to help the Nuon team do
     // support on any installs.
     "arn:aws:iam::766121324316:root",
   ]
@@ -13,13 +13,39 @@ locals {
 
 data "aws_iam_policy_document" "nuon_ecr_access_trust" {
   statement {
+    sid    = "NuonHostedAWS"
     effect = "Allow"
     actions = [
       "sts:AssumeRole"
     ]
     principals {
-    type = "AWS"
-    identifiers = local.principals
+      type        = "AWS"
+      identifiers = local.principals
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(var.gcp_principals) > 0 ? [1] : []
+    content {
+      sid    = "SelfHostedGCP"
+      effect = "Allow"
+      actions = [
+        "sts:AssumeRoleWithWebIdentity",
+      ]
+      principals {
+        type        = "Federated"
+        identifiers = ["accounts.google.com"]
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "accounts.google.com:aud"
+        values   = ["sts.amazonaws.com"]
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "accounts.google.com:sub"
+        values   = [for p in var.gcp_principals : p.service_account_unique_id]
+      }
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,3 +20,17 @@ variable "enable_support_access" {
   default     = true
   description = "Grant access to additional Nuon accounts for debugging support"
 }
+
+variable "gcp_principals" {
+  type = list(object({
+    service_account_unique_id = string
+    service_account_email     = optional(string)
+  }))
+  default     = []
+  description = <<-EOT
+    GCP service accounts allowed to assume this role via Workload Identity Federation,
+    for customers running self-hosted Nuon on GCP. Each entry must include the SA's
+    21-digit numeric uniqueId; the email is optional and used only as documentation.
+    Get the uniqueId with: gcloud iam service-accounts describe <email> --format='value(uniqueId)'
+  EOT
+}


### PR DESCRIPTION
## Summary
- Adds optional \`gcp_principals\` input (list of \`{ service_account_unique_id, service_account_email }\`)
- When non-empty, emits an additive \`AssumeRoleWithWebIdentity\` trust statement for \`accounts.google.com\` with \`aud=sts.amazonaws.com\` and \`sub\` matching the SA uniqueIds
- Backwards compatible — existing Nuon-hosted (AWS) trust unchanged

This unblocks customers running [self-hosted Nuon on GCP](https://docs.nuon.co/guides/self-hosted/gcp) from pulling private ECR images.

## Test plan
- [x] \`terraform validate\` passes (verified locally)
- [x] Manual smoke: apply with \`gcp_principals\` set, confirm trust policy contains both AWS and Federated statements
- [x] End-to-end: self-hosted GCP install pulls a private ECR image with this role