### PR TITLE
fix: drop accounts.google.com:aud condition

### DIFF
--- a/trust_policy.tf
+++ b/trust_policy.tf
@@ -36,11 +36,12 @@ data "aws_iam_policy_document" "nuon_ecr_access_trust" {
         type        = "Federated"
         identifiers = ["accounts.google.com"]
       }
-      condition {
-        test     = "StringEquals"
-        variable = "accounts.google.com:aud"
-        values   = ["sts.amazonaws.com"]
-      }
+      # AWS's legacy `accounts.google.com` Federated principal silently expects
+      # the audience claim to be a Google OAuth 2.0 client ID. Constraining
+      # `accounts.google.com:aud` to anything else (e.g. `sts.amazonaws.com`,
+      # which is what GCP-hosted ctl-api/runner request) causes every assume
+      # call to fail with a generic AccessDenied. Trust is anchored on the
+      # `sub` claim — the SA's globally-unique numeric uniqueId, never reused.
       condition {
         test     = "StringEquals"
         variable = "accounts.google.com:sub"

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,17 @@
 variable "role_name" {
-  type = string
+  type        = string
   description = "Role name to create, must be changed if creating more than one role"
-  default = "nuon-ecr-access"
+  default     = "nuon-ecr-access"
 }
 
 variable "policy_name" {
-  type = string
+  type        = string
   description = "Policy name to create, must be changed if creating more than one role"
-  default = "nuon-ecr-access"
+  default     = "nuon-ecr-access"
 }
 
 variable "repository_arns" {
-  type = list(string)
+  type        = list(string)
   description = "Repository ARN to grant access too"
 }
 


### PR DESCRIPTION
## Summary

AWS's legacy \`accounts.google.com\` Federated principal silently requires the audience claim to be a Google OAuth 2.0 client ID. Constraining \`accounts.google.com:aud\` to anything else — including \`sts.amazonaws.com\`, which is what GCP-hosted ctl-api and runner pods request via the GCE metadata endpoint — causes every \`AssumeRoleWithWebIdentity\` call to fail with a generic \`AccessDenied\` / \`"An unknown error occurred"\` in CloudTrail.

Trust now anchors on the \`sub\` claim alone (the SA's globally-unique numeric \`uniqueId\`, never reused across SAs), matching the policy shape that has historically worked for self-hosted-on-GCP installs.

## Test plan

- [x] Reproduced the failure end-to-end against a self-hosted-on-GCP install in \`nuon-byoc-gcp\` pulling from a customer ECR in \`us-west-2\` — every \`AssumeRoleWithWebIdentity\` call returned \`AccessDenied\` with \`identityProviderConnectionVerificationMethod: IAMTrustStore\` despite a correct \`sub\` match.
- [x] Patched the role's trust policy in place to drop the \`aud\` condition; the same install was then able to pull source successfully.
- [ ] After merge + tag (\`v0.1.8\`): re-run \`terraform apply\` against the customer's TF and verify the same outcome via the module instead of an out-of-band patch.