### PR TITLE
docs: correct gcp_principals README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ module "nuon_aws_ecr_access" {
 
 ### Customers running self-hosted Nuon on GCP
 
-If some of your customers run [self-hosted Nuon on GCP](https://docs.nuon.co/guides/self-hosted/gcp), pass each customer's
-ctl-api service account so the trust policy also accepts their GCP-issued OIDC tokens:
+If some of your customers run [self-hosted Nuon on GCP](https://docs.nuon.co/guides/self-hosted/gcp), pass each
+customer's GCP service account unique IDs via `gcp_principals` so the trust policy also accepts their GCP-issued OIDC
+tokens. Two SAs from the customer's project need to be listed:
+
+- The org runner SA (display name `Nuon org runner <org_id>`) — pulls source for builds.
+- The ctl-api SA (display name `ctl-api for <install_id>`) — fetches image metadata for `external_image` components.
 
 ```hcl
 module "nuon_aws_ecr_access" {
@@ -27,17 +31,28 @@ module "nuon_aws_ecr_access" {
 
   gcp_principals = [
     {
-      service_account_unique_id = "123456789012345678901"
-      service_account_email     = "ctl-api-<install>@<customer-project>.iam.gserviceaccount.com"
+      service_account_unique_id = "123456789012345678901" # org runner SA UID
+      service_account_email     = "<org-id-truncated>@<customer-project>.iam.gserviceaccount.com"
+    },
+    {
+      service_account_unique_id = "987654321098765432109" # ctl-api SA UID
+      service_account_email     = "ctl-api-<install-id-truncated>@<customer-project>.iam.gserviceaccount.com"
     },
   ]
 }
 ```
 
-The `service_account_unique_id` is the 21-digit numeric ID of the SA. Customers can find it with:
+`service_account_email` is documentation-only; the trust policy is anchored on `service_account_unique_id` (the SA's
+21-digit numeric `uniqueId`). Customers can look both up with:
 
 ```bash
-gcloud iam service-accounts describe <email> --format='value(uniqueId)'
+gcloud iam service-accounts list \
+  --project=<customer-project> \
+  --filter='displayName~"Nuon org runner" OR displayName~"ctl-api for"' \
+  --format='table(email,uniqueId,displayName)'
 ```
+
+Don't try to construct the SA emails by hand — Nuon truncates the org/install ID to fit GCP's 30-character SA name
+limit, and the truncation length varies by prefix. The full org/install ID is preserved in each SA's display name.
 
 This is additive — the role still accepts the default Nuon-hosted (AWS) principal.


### PR DESCRIPTION
## Summary

The previous README told customers to pass their \"ctl-api service account\" via \`gcp_principals\`, but that's only the SA used for image-metadata fetches on \`external_image\` components. The actual build path's source pull is performed by the GKE org-runner pod, which is Workload-Identity-bound to a *different* GCP SA (named after the org ID). With only the ctl-api SA in the trust policy, every build fails with \`AccessDenied\` on \`AssumeRoleWithWebIdentity\`.

Updated the README to:

- List both required SAs (org runner + ctl-api) with their display-name patterns so customers can identify them by sight.
- Replace the per-SA \`gcloud describe\` invocation with a single \`list\` command that returns email + uniqueId for both SAs at once.
- Warn that SA emails truncate the org/install ID by varying lengths to fit GCP's 30-char SA name limit, so emails can't be reliably constructed by hand.

## Test plan

- [x] Verified end-to-end against a self-hosted-on-GCP install (\`nuon-byoc-gcp\`): with both SAs in \`gcp_principals\`, the customer build can pull source from a customer ECR in \`us-west-2\`. With only the ctl-api SA, the build fails with \`AccessDenied\` as described.